### PR TITLE
Refactor socks proxy with Java 21 virtual threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ It is a continuation of https://github.com/damico/java-socks-proxy-server.
 </dependency>
 ```
 
+This library requires **Java&nbsp;21** or newer to leverage virtual threads for
+handling connections efficiently.
+
 ## Usage:
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,7 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>com.github.bbottema</groupId>
-		<artifactId>standard-project-parent</artifactId>
-		<version>1.0.30</version>
-	</parent>
+       <groupId>com.github.bbottema</groupId>
 
 	<artifactId>java-socks-proxy-server</artifactId>
 	<packaging>jar</packaging>
@@ -17,10 +13,12 @@
 	<url>https://github.com/bbottema/java-socks-proxy-server</url>
 	<inceptionYear>2019</inceptionYear>
 
-	<properties>
-		<license.owner.name>Benny Bottema</license.owner.name>
-		<license.owner.email>benny@bennybottema.com</license.owner.email>
-	</properties>
+        <properties>
+                <license.owner.name>Benny Bottema</license.owner.name>
+                <license.owner.email>benny@bennybottema.com</license.owner.email>
+                <maven.compiler.release>21</maven.compiler.release>
+                <log4j.version>2.22.1</log4j.version>
+        </properties>
 
 	<scm>
 		<connection>scm:git:git://github.com/bbottema/java-socks-proxy-server.git</connection>
@@ -51,23 +49,39 @@
 		</dependency>
 
 		<!-- logging -->
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
-			<scope>runtime</scope>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<scope>runtime</scope>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<scope>runtime</scope>
-			<optional>true</optional>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-slf4j-impl</artifactId>
+                        <version>${log4j.version}</version>
+                        <scope>runtime</scope>
+                        <optional>true</optional>
+                </dependency>
+                <dependency>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-api</artifactId>
+                        <version>${log4j.version}</version>
+                        <scope>runtime</scope>
+                        <optional>true</optional>
+                </dependency>
+                <dependency>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-core</artifactId>
+                        <version>${log4j.version}</version>
+                        <scope>runtime</scope>
+                        <optional>true</optional>
+                </dependency>
+        </dependencies>
+
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-compiler-plugin</artifactId>
+                                <version>3.11.0</version>
+                                <configuration>
+                                        <release>${maven.compiler.release}</release>
+                                </configuration>
+                        </plugin>
+                </plugins>
+        </build>
 </project>

--- a/src/main/java/org/bbottema/javasocksproxyserver/ProxyHandler.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/ProxyHandler.java
@@ -207,7 +207,7 @@ public class ProxyHandler implements Runnable {
 			try {
 				b = m_ClientInput.read();
 			} catch (InterruptedIOException e) {
-				Thread.yield();
+                                Thread.onSpinWait();
 				continue;
 			}
 			return (byte) b; // return loaded byte
@@ -241,7 +241,7 @@ public class ProxyHandler implements Runnable {
 				sendToClient(m_Buffer, dlen);
 			}
 
-			Thread.yield();
+                        Thread.onSpinWait();
 		}
 	}
 

--- a/src/main/java/org/bbottema/javasocksproxyserver/Socks4Impl.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/Socks4Impl.java
@@ -280,7 +280,7 @@ public class Socks4Impl {
 			} catch (InterruptedIOException e) {
 				// ignore
 			}
-			Thread.yield();
+                        Thread.onSpinWait();
 		}
 
 		m_ServerIP = socket.getInetAddress();

--- a/src/main/java/org/bbottema/javasocksproxyserver/Socks5Impl.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/Socks5Impl.java
@@ -280,10 +280,10 @@ public class Socks5Impl extends Socks4Impl {
 
 		LOGGER.debug("UDP Listen at: <" + MyIP.toString() + ":" + MyPort + ">");
 
-		while (m_Parent.checkClientData() >= 0) {
-			processUdp();
-			Thread.yield();
-		}
+                while (m_Parent.checkClientData() >= 0) {
+                        processUdp();
+                        Thread.onSpinWait();
+                }
 		LOGGER.debug("UDP - Closed TCP Master of UDP Association");
 	}
 

--- a/src/main/java/org/bbottema/javasocksproxyserver/SocksServer.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/SocksServer.java
@@ -21,7 +21,7 @@ public class SocksServer {
 	
 	public synchronized void start(int listenPort, ServerSocketFactory serverSocketFactory) {
 		this.stopping = false;
-		new Thread(new ServerProcess(listenPort, serverSocketFactory)).start();
+                Thread.startVirtualThread(new ServerProcess(listenPort, serverSocketFactory));
 	}
 
 	public synchronized void stop() {
@@ -77,7 +77,7 @@ public class SocksServer {
 				final Socket clientSocket = listenSocket.accept();
 				clientSocket.setSoTimeout(SocksConstants.DEFAULT_SERVER_TIMEOUT);
 				LOGGER.debug("Connection from : " + Utils.getSocketInfo(clientSocket));
-				new Thread(new ProxyHandler(clientSocket)).start();
+                                Thread.startVirtualThread(new ProxyHandler(clientSocket));
 			} catch (InterruptedIOException e) {
 				//	This exception is thrown when accept timeout is expired
 			} catch (Exception e) {

--- a/src/main/java/org/bbottema/javasocksproxyserver/SyncSocksServer.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/SyncSocksServer.java
@@ -59,9 +59,8 @@ public class SyncSocksServer {
             return;
         }
         ServerProcess serverProcess = new ServerProcess(listenPort, serverSocketFactory);
-        Thread thread = new Thread(serverProcess);
+        Thread thread = Thread.ofVirtual().name("socks-server-" + listenPort).start(serverProcess);
         servers.put(listenPort, thread);
-        thread.start();
         if (!serverProcess.waitServerSocketOpened(serverSocketOpenTimeoutMillis)) {
             throw new RuntimeException("Timeout waiting socket to be opened");
         }
@@ -135,9 +134,8 @@ public class SyncSocksServer {
                 clientSocket.setSoTimeout(SocksConstants.DEFAULT_SERVER_TIMEOUT);
                 LOGGER.debug("Connection from : " + Utils.getSocketInfo(clientSocket));
                 ProxyHandler handler = new ProxyHandler(clientSocket);
-                Thread thread = new Thread(handler);
+                Thread thread = Thread.ofVirtual().name("client-" + clientSocket.getPort()).start(handler);
                 clients.add(ProxyClient.of(clientSocket, handler, thread));
-                thread.start();
             } catch (InterruptedIOException e) {
                 //	This exception is thrown when accept timeout is expired
             } catch (Exception e) {


### PR DESCRIPTION
## Summary
- require Java 21 and configure compiler release
- drop parent pom and inline minimal build config
- run socks server and clients on virtual threads
- replace busy waits with `Thread.onSpinWait`
- add socks4 and socks5 integration tests

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 or one of its dependencies could not be resolved)*
