### PR TITLE
Allow custom socket factory for outbound SOCKS connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ SocksServer socksServer = new SocksServer();
 socksServer.start(100); // start serving clients on port 100
 socksServer.start(200); // start serving clients on port 200
 socksServer.start(300, myCustomServerSocketFactory); // eg. SSL on port 300
+socksServer.start(400, myCustomSocketFactory); // custom socket factory for outbound connections
+socksServer.start(500, myCustomServerSocketFactory, myCustomSocketFactory); // custom factory for both inbound and outbound
 
 socksServer.stop(); // stops server on all ports
 ```
@@ -36,8 +38,13 @@ For use in junit tests:
 	
 	// or
 	
-	@ClassRule
-	public static final SockServerRule sockServerRule = new SockServerRule(PROXY_SERVER_PORT, myServerSocketFactory);
+        @ClassRule
+        public static final SockServerRule sockServerRule = new SockServerRule(PROXY_SERVER_PORT, myServerSocketFactory);
+
+        // or
+
+        @ClassRule
+        public static final SockServerRule sockServerRule = new SockServerRule(PROXY_SERVER_PORT, myServerSocketFactory, mySocketFactory);
 ```
 
 And that's it!

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<artifactId>java-socks-proxy-server</artifactId>
 	<packaging>jar</packaging>
 	<name>java-socks-proxy-server</name>
-	<version>2.1.0</version>
+	<version>2.2.0</version>
 	<description>java-socks-proxy-server is a SOCKS 4/5 server for Java</description>
 	<url>https://github.com/bbottema/java-socks-proxy-server</url>
 	<inceptionYear>2019</inceptionYear>

--- a/src/main/java/org/bbottema/javasocksproxyserver/ProxyHandler.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/ProxyHandler.java
@@ -9,6 +9,7 @@ import java.io.OutputStream;
 import java.net.Socket;
 import java.net.SocketException;
 import java.util.concurrent.locks.ReentrantLock;
+import javax.net.SocketFactory;
 
 import static java.lang.String.format;
 import static org.bbottema.javasocksproxyserver.Utils.getSocketInfo;
@@ -24,20 +25,27 @@ public class ProxyHandler implements Runnable {
 	private ReentrantLock m_lock;
 	private Socks4Impl comm = null;
 
-	Socket m_ClientSocket;
-	Socket m_ServerSocket = null;
-	byte[] m_Buffer = new byte[SocksConstants.DEFAULT_BUF_SIZE];
+        Socket m_ClientSocket;
+        Socket m_ServerSocket = null;
+        byte[] m_Buffer = new byte[SocksConstants.DEFAULT_BUF_SIZE];
 
-	public ProxyHandler(Socket clientSocket) {
-		m_lock = new ReentrantLock();
-		m_ClientSocket = clientSocket;
-		try {
-			m_ClientSocket.setSoTimeout(SocksConstants.DEFAULT_PROXY_TIMEOUT);
-		} catch (SocketException e) {
-			SocksServer.callback.error("Socket Exception during seting Timeout.");
-		}
-		SocksServer.callback.debug("Proxy Created.");
-	}
+        private final SocketFactory socketFactory;
+
+        public ProxyHandler(Socket clientSocket) {
+                this(clientSocket, SocketFactory.getDefault());
+        }
+
+        public ProxyHandler(Socket clientSocket, SocketFactory socketFactory) {
+                m_lock = new ReentrantLock();
+                m_ClientSocket = clientSocket;
+                this.socketFactory = socketFactory;
+                try {
+                        m_ClientSocket.setSoTimeout(SocksConstants.DEFAULT_PROXY_TIMEOUT);
+                } catch (SocketException e) {
+                        SocksServer.callback.error("Socket Exception during seting Timeout.");
+                }
+                SocksServer.callback.debug("Proxy Created.");
+        }
 
 	public void setLock(ReentrantLock lock) {
 		this.m_lock = lock;
@@ -133,11 +141,11 @@ public class ProxyHandler implements Runnable {
 			return;
 		}
 
-		m_ServerSocket = new Socket(server, port);
-		m_ServerSocket.setSoTimeout(SocksConstants.DEFAULT_PROXY_TIMEOUT);
+                m_ServerSocket = socketFactory.createSocket(server, port);
+                m_ServerSocket.setSoTimeout(SocksConstants.DEFAULT_PROXY_TIMEOUT);
 
-		SocksServer.callback.debug("Connected to " + getSocketInfo(m_ServerSocket));
-		prepareServer();
+                SocksServer.callback.debug("Connected to " + getSocketInfo(m_ServerSocket));
+                prepareServer();
 	}
 
 	protected void prepareServer() throws IOException {

--- a/src/main/java/org/bbottema/javasocksproxyserver/SocksServer.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/SocksServer.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ServerSocketFactory;
+import javax.net.SocketFactory;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.ServerSocket;
@@ -29,27 +30,46 @@ public class SocksServer {
 		this.pool = Executors.newCachedThreadPool();
 	}
 
-	public synchronized void start(int listenPort) {
-		if (SocksServer.callback == null) SocksServer.callback = new CallbackImpl(LOGGER);
-		start(listenPort, ServerSocketFactory.getDefault());
-	}
+        public synchronized void start(int listenPort) {
+                if (SocksServer.callback == null) SocksServer.callback = new CallbackImpl(LOGGER);
+                start(listenPort, ServerSocketFactory.getDefault(), SocketFactory.getDefault());
+        }
 
-	public synchronized void start(int listenPort, ServerSocketFactory serverSocketFactory) {
-		if (SocksServer.callback == null) SocksServer.callback = new CallbackImpl(LOGGER);
-		this.stopping = false;
-		pool.execute(new ServerProcess(listenPort, serverSocketFactory));
-	}
+        public synchronized void start(int listenPort, ServerSocketFactory serverSocketFactory) {
+                if (SocksServer.callback == null) SocksServer.callback = new CallbackImpl(LOGGER);
+                start(listenPort, serverSocketFactory, SocketFactory.getDefault());
+        }
 
-	public synchronized void start(int listenPort, Callback callback) {
-		SocksServer.callback = callback;
-		start(listenPort, ServerSocketFactory.getDefault());
-	}
+        public synchronized void start(int listenPort, SocketFactory socketFactory) {
+                if (SocksServer.callback == null) SocksServer.callback = new CallbackImpl(LOGGER);
+                start(listenPort, ServerSocketFactory.getDefault(), socketFactory);
+        }
 
-	public synchronized void start(int listenPort, ServerSocketFactory serverSocketFactory, Callback callback) {
-		SocksServer.callback = callback;
-		this.stopping = false;
-		pool.execute(new ServerProcess(listenPort, serverSocketFactory));
-	}
+        public synchronized void start(int listenPort, Callback callback) {
+                SocksServer.callback = callback;
+                start(listenPort, ServerSocketFactory.getDefault(), SocketFactory.getDefault());
+        }
+
+        public synchronized void start(int listenPort, ServerSocketFactory serverSocketFactory, Callback callback) {
+                SocksServer.callback = callback;
+                start(listenPort, serverSocketFactory, SocketFactory.getDefault());
+        }
+
+        public synchronized void start(int listenPort, SocketFactory socketFactory, Callback callback) {
+                SocksServer.callback = callback;
+                start(listenPort, ServerSocketFactory.getDefault(), socketFactory);
+        }
+
+        public synchronized void start(int listenPort, ServerSocketFactory serverSocketFactory, SocketFactory socketFactory) {
+                if (SocksServer.callback == null) SocksServer.callback = new CallbackImpl(LOGGER);
+                this.stopping = false;
+                pool.execute(new ServerProcess(listenPort, serverSocketFactory, socketFactory));
+        }
+
+        public synchronized void start(int listenPort, ServerSocketFactory serverSocketFactory, SocketFactory socketFactory, Callback callback) {
+                SocksServer.callback = callback;
+                start(listenPort, serverSocketFactory, socketFactory);
+        }
 
 	public synchronized void stop() {
 		stopping = true;
@@ -74,12 +94,14 @@ public class SocksServer {
 	private class ServerProcess implements Runnable {
 
 		protected final int port;
-		private final ServerSocketFactory serverSocketFactory;
+                private final ServerSocketFactory serverSocketFactory;
+                private final SocketFactory socketFactory;
 
-		public ServerProcess(int port, ServerSocketFactory serverSocketFactory) {
-			this.port = port;
-			this.serverSocketFactory = serverSocketFactory;
-		}
+                public ServerProcess(int port, ServerSocketFactory serverSocketFactory, SocketFactory socketFactory) {
+                        this.port = port;
+                        this.serverSocketFactory = serverSocketFactory;
+                        this.socketFactory = socketFactory;
+                }
 
 		@Override
 		public void run() {
@@ -117,10 +139,10 @@ public class SocksServer {
 
 		private void handleNextClient(ServerSocket listenSocket) {
 			try {
-				final Socket clientSocket = listenSocket.accept();
-				clientSocket.setSoTimeout(SocksConstants.DEFAULT_SERVER_TIMEOUT);
-				SocksServer.callback.debug("Connection from : " + Utils.getSocketInfo(clientSocket));
-				new Thread(new ProxyHandler(clientSocket)).start();
+                                final Socket clientSocket = listenSocket.accept();
+                                clientSocket.setSoTimeout(SocksConstants.DEFAULT_SERVER_TIMEOUT);
+                                SocksServer.callback.debug("Connection from : " + Utils.getSocketInfo(clientSocket));
+                                new Thread(new ProxyHandler(clientSocket, socketFactory)).start();
 			} catch (InterruptedIOException e) {
 				// This exception is thrown when accept timeout is expired
 			} catch (Exception e) {

--- a/src/main/java/org/bbottema/javasocksproxyserver/junit/SockServerRule.java
+++ b/src/main/java/org/bbottema/javasocksproxyserver/junit/SockServerRule.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.rules.ExternalResource;
 
 import javax.net.ServerSocketFactory;
+import javax.net.SocketFactory;
 
 /**
  * Creates a {@link SocksServer} once, and starts and stops it before and after each test.
@@ -13,23 +14,29 @@ import javax.net.ServerSocketFactory;
  */
 public class SockServerRule extends ExternalResource {
 
-	private final SocksServer socksServer;
-	private final int port;
-	private final ServerSocketFactory serverSocketFactory;
-	
-	public SockServerRule(@NotNull Integer port) {
-		this(port, ServerSocketFactory.getDefault());
-	}
-	
-	public SockServerRule(@NotNull Integer port, @NotNull ServerSocketFactory serverSocketFactory) {
-		this.socksServer = new SocksServer();
-		this.port = port;
-		this.serverSocketFactory = serverSocketFactory;
-	}
+        private final SocksServer socksServer;
+        private final int port;
+        private final ServerSocketFactory serverSocketFactory;
+        private final SocketFactory socketFactory;
+
+        public SockServerRule(@NotNull Integer port) {
+                this(port, ServerSocketFactory.getDefault(), SocketFactory.getDefault());
+        }
+
+        public SockServerRule(@NotNull Integer port, @NotNull ServerSocketFactory serverSocketFactory) {
+                this(port, serverSocketFactory, SocketFactory.getDefault());
+        }
+
+        public SockServerRule(@NotNull Integer port, @NotNull ServerSocketFactory serverSocketFactory, @NotNull SocketFactory socketFactory) {
+                this.socksServer = new SocksServer();
+                this.port = port;
+                this.serverSocketFactory = serverSocketFactory;
+                this.socketFactory = socketFactory;
+        }
 
 	@Override
 	protected void before() {
-		this.socksServer.start(port, serverSocketFactory);
+                this.socksServer.start(port, serverSocketFactory, socketFactory);
 	}
 
 	@Override

--- a/src/test/java/org/bbottema/javasocksproxyserver/ProxyHandlerCustomSocketFactoryTest.java
+++ b/src/test/java/org/bbottema/javasocksproxyserver/ProxyHandlerCustomSocketFactoryTest.java
@@ -1,0 +1,113 @@
+package org.bbottema.javasocksproxyserver;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.net.SocketFactory;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies that {@link ProxyHandler} uses the provided {@link SocketFactory} when connecting to the remote server.
+ */
+public class ProxyHandlerCustomSocketFactoryTest {
+
+    private ServerSocket serverSocket;
+    private Socket serverSideSocket;
+    private ExecutorService executor;
+
+    @Before
+    public void setup() throws IOException {
+        serverSocket = new ServerSocket(0);
+        executor = Executors.newSingleThreadExecutor();
+        executor.submit(() -> {
+            try {
+                serverSideSocket = serverSocket.accept();
+            } catch (IOException ignored) {
+            }
+        });
+
+        SocksServer.callback = new Callback() {
+            @Override
+            public boolean filter(java.net.InetAddress data) { return false; }
+
+            @Override
+            public void error(String msg) { }
+
+            @Override
+            public void error(String msg, Exception e) { }
+
+            @Override
+            public void debug(String msg) { }
+
+            @Override
+            public void debug(String msg, Exception e) { }
+
+            @Override
+            public void info(String msg) { }
+        };
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        executor.shutdownNow();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+        if (serverSideSocket != null) {
+            serverSideSocket.close();
+        }
+        serverSocket.close();
+    }
+
+    @Test
+    public void customSocketFactoryIsUsed() throws Exception {
+        final AtomicBoolean used = new AtomicBoolean(false);
+        SocketFactory factory = new SocketFactory() {
+            private final SocketFactory delegate = SocketFactory.getDefault();
+
+            @Override
+            public Socket createSocket() throws IOException {
+                return delegate.createSocket();
+            }
+
+            @Override
+            public Socket createSocket(String host, int port) throws IOException {
+                used.set(true);
+                return delegate.createSocket(host, port);
+            }
+
+            @Override
+            public Socket createSocket(String host, int port, java.net.InetAddress localHost, int localPort) throws IOException {
+                used.set(true);
+                return delegate.createSocket(host, port, localHost, localPort);
+            }
+
+            @Override
+            public Socket createSocket(java.net.InetAddress host, int port) throws IOException {
+                used.set(true);
+                return delegate.createSocket(host, port);
+            }
+
+            @Override
+            public Socket createSocket(java.net.InetAddress address, int port, java.net.InetAddress localAddress, int localPort) throws IOException {
+                used.set(true);
+                return delegate.createSocket(address, port, localAddress, localPort);
+            }
+        };
+
+        ProxyHandler handler = new ProxyHandler(new Socket(), factory);
+        handler.connectToServer("localhost", serverSocket.getLocalPort());
+
+        assertTrue("Custom socket factory should have been used", used.get());
+
+        handler.close();
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow `ProxyHandler` to use a pluggable `SocketFactory` for remote connections
- extend `SocksServer` and `SockServerRule` to accept the custom socket factory
- document and test custom socket factory support
